### PR TITLE
support jetson-nano 4gb B01 model

### DIFF
--- a/create-image.sh
+++ b/create-image.sh
@@ -63,9 +63,15 @@ case "$JETSON_NANO_BOARD" in
         printf "OK\n"
         ;;
 
-    jetson-nano)
-        printf "Create image for Jetson nano board"
+    jetson-nano-4gb-a01)
+        printf "Create image for Jetson nano 4GB (A02) board"
         ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r 200
+        printf "OK\n"
+        ;;
+
+    jetson-nano-4gb-b01)
+        printf "Create image for Jetson nano 4GB (B01) board"
+        ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r 300
         printf "OK\n"
         ;;
 

--- a/create-image.sh
+++ b/create-image.sh
@@ -63,7 +63,7 @@ case "$JETSON_NANO_BOARD" in
         printf "OK\n"
         ;;
 
-    jetson-nano-4gb-a01)
+    jetson-nano-4gb-a02)
         printf "Create image for Jetson nano 4GB (A02) board"
         ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r 200
         printf "OK\n"

--- a/create-image.sh
+++ b/create-image.sh
@@ -10,26 +10,26 @@ BSP=https://developer.nvidia.com/embedded/l4t/r32_release_v5.1/r32_release_v5.1/
 
 # Check if the user is not root
 if [ "x$(whoami)" != "xroot" ]; then
-        printf "\e[31mThis script requires root privilege\e[0m\n"
-        exit 1
+    printf "\e[31mThis script requires root privilege\e[0m\n"
+    exit 1
 fi
 
 # Check for env variables
 if [ ! $JETSON_ROOTFS_DIR ] || [ ! $JETSON_BUILD_DIR ]; then
-	printf "\e[31mYou need to set the env variables \$JETSON_ROOTFS_DIR and \$JETSON_BUILD_DIR\e[0m\n"
-	exit 1
+    printf "\e[31mYou need to set the env variables \$JETSON_ROOTFS_DIR and \$JETSON_BUILD_DIR\e[0m\n"
+    exit 1
 fi
 
 # Check if $JETSON_ROOTFS_DIR if not empty
 if [ ! "$(ls -A $JETSON_ROOTFS_DIR)" ]; then
-	printf "\e[31mNo rootfs found in $JETSON_ROOTFS_DIR\e[0m\n"
-	exit 1
+    printf "\e[31mNo rootfs found in $JETSON_ROOTFS_DIR\e[0m\n"
+    exit 1
 fi
 
 # Check if board type is specified
 if [ ! $JETSON_NANO_BOARD ]; then
-	printf "\e[31mJetson nano board type must be specified\e[0m\n"
-	exit 1
+    printf "\e[31mJetson nano board type must be specified\e[0m\n"
+    exit 1
 fi
 
 printf "\e[32mBuild the image ...\n"
@@ -39,10 +39,10 @@ mkdir -p $JETSON_BUILD_DIR
 
 # Download L4T
 if [ ! "$(ls -A $JETSON_BUILD_DIR)" ]; then
-        printf "\e[32mDownload L4T...       "
-        wget -qO- $BSP | tar -jxpf - -C $JETSON_BUILD_DIR
-	rm $JETSON_BUILD_DIR/Linux_for_Tegra/rootfs/README.txt
-        printf "[OK]\n"
+    printf "\e[32mDownload L4T...       "
+    wget -qO- $BSP | tar -jxpf - -C $JETSON_BUILD_DIR
+    rm $JETSON_BUILD_DIR/Linux_for_Tegra/rootfs/README.txt
+    printf "[OK]\n"
 fi
 
 cp -rp $JETSON_ROOTFS_DIR/*  $JETSON_BUILD_DIR/Linux_for_Tegra/rootfs/ > /dev/null
@@ -63,21 +63,17 @@ case "$JETSON_NANO_BOARD" in
         printf "OK\n"
         ;;
 
-    jetson-nano-4gb-a02)
-        printf "Create image for Jetson nano 4GB (A02) board"
-        ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r 200
+    jetson-nano)
+        # default value for boad rev is 200
+        nano_board_rev="${JETSON_NANO_REVISION:=200}"
+        printf "Create image for Jetson nano 4GB ($nano_board_rev) board"
+        ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r $nano_board_rev
         printf "OK\n"
         ;;
-
-    jetson-nano-4gb-b01)
-        printf "Create image for Jetson nano 4GB (B01) board"
-        ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r 300
-        printf "OK\n"
-        ;;
-
+    
     *)
-	printf "\e[31mUnknown Jetson nano board type\e[0m\n"
-	exit 1
+    printf "\e[31mUnknown Jetson nano board type\e[0m\n"
+    exit 1
         ;;
 esac
 

--- a/create-image.sh
+++ b/create-image.sh
@@ -66,7 +66,7 @@ case "$JETSON_NANO_BOARD" in
     jetson-nano)
         # default value for boad rev is 200
         nano_board_rev="${JETSON_NANO_REVISION:=200}"
-        printf "Create image for Jetson nano 4GB ($nano_board_rev) board"
+        printf "Create image for Jetson nano 4GB board ($nano_board_rev)"
         ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r $nano_board_rev
         printf "OK\n"
         ;;


### PR DESCRIPTION
Hi,

Thanks for this great work.

There are two nano dev kits - A02 and B01. Mostly if you purchase now then you will only get B01. I have B01 from more than 1 year now.

At present, the argument to jetson-image-creator in your script is taking 200. This is valid for A02 but for B01 it should 300.

I have taken the liberty to add support by changing the requirement for the value of the JETSON_NANO_BOARD environment variable.

I understand that unfortunately, this change will break your blog post.

Regards
Kapil