### PR TITLE
Update netcfg.yaml

### DIFF
--- a/ansible/roles/jetson/templates/etc/netplan/netcfg.yaml
+++ b/ansible/roles/jetson/templates/etc/netplan/netcfg.yaml
@@ -10,7 +10,7 @@ network:
   #     dhcp4-overrides:
   #       use-dns: no
   #     nameservers:
-  #       - 127.0.0.53
+  #       addresses: [8.8.8.8,8.8.4.4]
   #     access-points:
   #       YOUR_ACCESS_POINT:
   #         password: WIFI_PASSWORD


### PR DESCRIPTION
Fix template for wifis, the `nameservers` was expecting `addresses` parameter.