### PR TITLE
Add Github Actions based workflows that builds the image and attaches artifacts to a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ on:
   # Run any PRs.
   pull_request:
 
-env:
-  JETSON_ROOTFS_DIR: /jetson-rootfs
-
 jobs:
-  build:
+  nano-2gb:
     runs-on: ubuntu-latest
-
+    env:
+      JETSON_ROOTFS_DIR: /jetson-nano-2gb-rootfs
+      JETSON_NANO_BOARD: jetson-nano-2gb
+      JETSON_BUILD_DIR: /jetson-nano-2gb-build
     steps:
       - uses: actions/checkout@v2
         with:
@@ -31,3 +31,7 @@ jobs:
         run: |
           cd ansible
           sudo -E $(which ansible-playbook) jetson.yaml
+
+      - name: Build image
+        run: |
+          sudo -E ./create-image.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  # Run jobs on push to master or feature branches
+  push:
+    branches:
+      - master
+      - feature-*
+
+  # Run any PRs.
+  pull_request:
+
+env:
+  JETSON_ROOTFS_DIR: /jetson-rootfs
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      
+      - name: Create rootfs
+        run: |
+          sudo -E ./create-rootfs.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
       - feature-*
 
   # Run any PRs.
@@ -25,3 +26,8 @@ jobs:
       - name: Create rootfs
         run: |
           sudo -E ./create-rootfs.sh
+
+      - name: Customize rootfs
+        run: |
+          cd ansible
+          sudo -E $(which ansible-playbook) jetson.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,29 @@ jobs:
       - name: Build image
         run: |
           sudo -E ./create-image.sh
+
+  nano-4gb:
+    runs-on: ubuntu-latest
+    env:
+      JETSON_ROOTFS_DIR: /nano-rootfs
+      JETSON_NANO_BOARD: jetson-nano
+      JETSON_BUILD_DIR: /nano-build
+      # Default is B01, set to 200 for A02
+      JETSON_NANO_REVISION: 300
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      
+      - name: Create rootfs
+        run: |
+          sudo -E ./create-rootfs.sh
+
+      - name: Customize rootfs
+        run: |
+          cd ansible
+          sudo -E $(which ansible-playbook) jetson.yaml
+
+      - name: Build image
+        run: |
+          sudo -E ./create-image.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+on:
+  release:
+    types: [edited, published]
+    branches:
+      - main
+      - feature-*
+
+jobs:
+  nano-2gb:
+    runs-on: ubuntu-latest
+    env:
+      JETSON_ROOTFS_DIR: /nano-2gb-rootfs
+      JETSON_NANO_BOARD: jetson-nano-2gb
+      JETSON_BUILD_DIR: /nano-2gb-build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      
+      - name: Create rootfs
+        run: |
+          sudo -E ./create-rootfs.sh
+
+      - name: Customize rootfs
+        run: |
+          cd ansible
+          sudo -E $(which ansible-playbook) jetson.yaml
+
+      - name: Build image
+        run: |
+          sudo -E ./create-image.sh
+
+      - name: Make tarball
+        run: |
+          tar -czvf "jetson-nano-2gb.tar.gz" "/nano-2gb-build/tools/jetson.img"
+      
+      - name: Publish binaries  
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: jetson-nano-2gb.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,41 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson-nano-2gb.tar.gz"
+  
+  nano-4gb:
+    runs-on: ubuntu-latest
+    env:
+      JETSON_ROOTFS_DIR: /nano-rootfs
+      JETSON_NANO_BOARD: jetson-nano
+      JETSON_BUILD_DIR: /nano-build
+      # Default is B01, set to 200 for A02
+      JETSON_NANO_REVISION: 300
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      
+      - name: Create rootfs
+        run: |
+          sudo -E ./create-rootfs.sh
+
+      - name: Customize rootfs
+        run: |
+          cd ansible
+          sudo -E $(which ansible-playbook) jetson.yaml
+
+      - name: Build image
+        run: |
+          sudo -E ./create-image.sh
+
+      - name: Make tarball
+        run: |
+          cd "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools"
+          tar -czvf "jetson-nano.tar.gz" "jetson.img"
+      
+      - name: Publish binaries  
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson-nano.tar.gz"  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson-nano-2gb.tar.gz"
+          args: "jetson-nano-2gb.tar.gz"
   
   nano-4gb:
     runs-on: ubuntu-latest
@@ -77,4 +77,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson-nano.tar.gz"  
+          args: "jetson-nano.tar.gz"  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Make tarball
         run: |
-          cd "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools"
-          tar -czvf "jetson-nano-2gb.tar.gz" "jetson.img"
+          tar -czvf "jetson-nano-2gb.tar.gz" -C "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools" "jetson.img"
       
       - name: Publish binaries  
         uses: skx/github-action-publish-binaries@master
@@ -71,8 +70,7 @@ jobs:
 
       - name: Make tarball
         run: |
-          cd "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools"
-          tar -czvf "jetson-nano.tar.gz" "jetson.img"
+          tar -czvf "jetson-nano.tar.gz" -C "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools" "jetson.img"
       
       - name: Publish binaries  
         uses: skx/github-action-publish-binaries@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Make tarball
         run: |
-          tar -czvf "jetson-nano-2gb.tar.gz" "/nano-2gb-build/tools/jetson.img"
+          tar -czvf "jetson-nano-2gb.tar.gz" "/${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson.img"
       
       - name: Publish binaries  
         uses: skx/github-action-publish-binaries@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,12 @@ jobs:
 
       - name: Make tarball
         run: |
-          tar -czvf "jetson-nano-2gb.tar.gz" "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson.img"
+          cd "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools"
+          tar -czvf "jetson-nano-2gb.tar.gz" "jetson.img"
       
       - name: Publish binaries  
         uses: skx/github-action-publish-binaries@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: jetson-nano-2gb.tar.gz
+          args: "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson-nano-2gb.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Make tarball
         run: |
-          tar -czvf "jetson-nano-2gb.tar.gz" "/${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson.img"
+          tar -czvf "jetson-nano-2gb.tar.gz" "${JETSON_BUILD_DIR}/Linux_for_Tegra/tools/jetson.img"
       
       - name: Publish binaries  
         uses: skx/github-action-publish-binaries@master

--- a/ansible/roles/jetson/defaults/main.yaml
+++ b/ansible/roles/jetson/defaults/main.yaml
@@ -2,6 +2,6 @@
 ubuntu_release: focal
 
 new_user:
-  name: pythops
+  name: nano
   shell: /bin/bash
-  password: pythops
+  password: jetson

--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -98,6 +98,7 @@
     - usbutils
     - vim
     - wpasupplicant
+    - parted
 
 - name: Generate locales
   locale_gen:

--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -108,6 +108,8 @@
   systemd:
     name: "{{ item }}"
     enabled: yes
+    masked: no
+    daemon_reload: yes
   loop:
     - ssh
     - systemd-networkd

--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -109,7 +109,6 @@
     name: "{{ item }}"
     enabled: yes
     masked: no
-    daemon_reload: yes
   loop:
     - ssh
     - systemd-networkd

--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -111,6 +111,7 @@
   loop:
     - ssh
     - systemd-networkd
+    - resizerootfs
 
 - name: Update network conf
   template:

--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -141,3 +141,8 @@
   shell: python3 /tmp/get-pip.py --user
   become: yes
   become_user: "{{ new_user.name }}"
+
+- name: Set hostname
+  shell: |
+    echo /etc/hostname > "jetson"
+    echo /etc/hosts >> "127.0.1.1 jetson"

--- a/create-rootfs.sh
+++ b/create-rootfs.sh
@@ -54,4 +54,10 @@ printf "Run debootstrap second stage... "
 chroot $JETSON_ROOTFS_DIR /bin/bash -c "/debootstrap/debootstrap --second-stage" > /dev/null
 printf "[OK]\n"
 
+# Copy additional files we want injected into rootfs
+printf "Copying additional files into rootfs..."
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cp -rf ${SCRIPT_DIR}/files/* $JETSON_ROOTFS_DIR/
+printf "[OK]\n"
+
 printf "Success!\n"

--- a/files/etc/systemd/system/resizerootfs.service
+++ b/files/etc/systemd/system/resizerootfs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Resize root file system
+Before=local-fs-pre.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+TimeoutSec=infinity
+ExecStart=/usr/sbin/resizerootfs
+ExecStart=/bin/systemctl --no-reload disable %n
+
+[Install]
+RequiredBy=local-fs-pre.target

--- a/files/usr/sbin/resizerootfs
+++ b/files/usr/sbin/resizerootfs
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -x
+
+roottmp=$(lsblk -l -o NAME,MOUNTPOINT | grep '/$')
+rootpart=/dev/${roottmp%% */}
+rootdev=/dev/$(echo "${roottmp}" | awk '{split($0,a,"p"); print a[1]}')
+cnt=$(echo "${rootpart}" | awk '{split($0,a,"p"); print a[2]}')
+
+flock "${rootdev}" sfdisk -f "${rootdev}" -N "${cnt}" <<EOF
+,+
+EOF
+
+sleep 5
+
+udevadm settle
+
+sleep 5
+
+flock "${rootdev}" partprobe "${rootdev}"
+
+mount -o remount,rw "${rootpart}"
+
+resize2fs "${rootpart}"
+
+exit 0


### PR DESCRIPTION
Use Github Actions to build the Jetson nano images directly in the cloud and attach to a release. This allows anyone to easily customize their own images as well as create ready-to-use images for custom applications without having to build it locally.

The image also contains resizerootfs, a service that runs at first boot and resizes the root partition to fill all available space on the SD card (like RaspiOS). This means that users can directly burn an image using Balena or Raspberry Pi Imager and it should "just work"