### PR TITLE
Add resizerootfs service

### DIFF
--- a/ansible/roles/jetson/files/resizerootfs
+++ b/ansible/roles/jetson/files/resizerootfs
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -x
+
+roottmp=$(lsblk -l -o NAME,MOUNTPOINT | grep '/$')
+rootpart=/dev/${roottmp%% */}
+rootdev=/dev/$(echo "${roottmp}" | awk '{split($0,a,"p"); print a[1]}')
+cnt=$(echo "${rootpart}" | awk '{split($0,a,"p"); print a[2]}')
+
+flock "${rootdev}" sfdisk -f "${rootdev}" -N "${cnt}" <<EOF
+,+
+EOF
+
+sleep 5
+
+udevadm settle
+
+sleep 5
+
+flock "${rootdev}" partprobe "${rootdev}"
+
+mount -o remount,rw "${rootpart}"
+
+resize2fs "${rootpart}"
+
+exit 0 

--- a/ansible/roles/jetson/files/resizerootfs.service
+++ b/ansible/roles/jetson/files/resizerootfs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Resize root file system
+Before=local-fs-pre.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+TimeoutSec=infinity
+ExecStart=/usr/sbin/resizerootfs
+ExecStart=/bin/systemctl --no-reload disable %n
+
+[Install]
+RequiredBy=local-fs-pre.target 

--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -72,6 +72,22 @@
     - usbutils
     - neovim
     - wpasupplicant
+    - parted
+
+- name: Copy resizerootfs.service
+  copy:
+    src: files/resizerootfs.service
+    dest: /etc/systemd/system/resizerootfs.service
+    owner: root
+    group: root
+
+- name: Copy resizerootfs
+  copy:
+    src: files/resizerootfs
+    dest: /usr/sbin/resizerootfs
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Generate locales
   locale_gen:
@@ -82,9 +98,11 @@
   systemd:
     name: "{{ item }}"
     enabled: yes
+    masked: no
   loop:
     - ssh
     - systemd-networkd
+    - resizerootfs
 
 - name: Update network conf
   template:


### PR DESCRIPTION
The resizerootfs service runs at first boot and resizes the root partition to fill available space. This allows users to directly write the image using `dd` or apps like Balena Etcher.

--

This is a re-worked version of https://github.com/pythops/jetson-nano-image/pull/48 to copy the files using ansible.