### PR TITLE
Adding support for Bionic BSP 32.7.1 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@
 https://pythops.com/post/create-your-own-image-for-jetson-nano-board.html
 
 ## Spec:
-**Ubuntu release**: 20.04
+**Ubuntu release**: 18.04
 
 **BSP**: 32.7.1
 

--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -1,114 +1,135 @@
 ---
-- name: Update /etc/apt/sources.list
-  template:
-    src: etc/apt/sources.list
-    dest: /etc/apt/sources.list
-    owner: root
-    group: root
-    mode: 0644
+  - block: 
+    - name: Update /etc/apt/sources.list
+      template:
+        src: etc/apt/sources.list
+        dest: /etc/apt/sources.list
+        owner: root
+        group: root
+        mode: 0644
 
-- name: Upgrade packages
-  apt:
-    upgrade: dist
-    update_cache: yes
+    - name: Upgrade packages
+      apt:
+        upgrade: dist
+        update_cache: yes
 
-- name: Install Nvidia required packages
-  apt:
-    name: "{{ item }}"
-    state: present
-  loop:
-    - libgles2
-    - libpangoft2-1.0-0
-    - libxkbcommon0
-    - libwayland-egl1
-    - libwayland-cursor0
-    - libunwind8
-    - libasound2
-    - libpixman-1-0
-    - libjpeg-turbo8
-    - libinput10
-    - libcairo2
-    - device-tree-compiler
-    - iso-codes
-    - libffi6
-    - libncursesw5
-    - libdrm-common
-    - libdrm2
-    - libegl-mesa0
-    - libegl1
-    - libegl1-mesa
-    - libgtk-3-0
-    - python2
-    - python-is-python2
-    - libgstreamer1.0-0
-    - libgstreamer-plugins-bad1.0-0
+    - name: Install Nvidia required packages
+      apt:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - libasound2
+        - libgles2
+        - libpangoft2-1.0-0
+        - libxkbcommon0
+        - libharfbuzz0b
+        - libwayland-egl1
+        - libwayland-cursor0
+        - libunwind8
+        - libpng16-16
+        - libpixman-1-0
+        - libjpeg-turbo8
+        - libinput10
+        - libevdev2
+        - libcairo2
+        - device-tree-compiler
+        - iso-codes
+        - libffi6
+        - libncursesw5
+        - libpython3-stdlib
+        - libpython3.8-minimal
+        - libpython3.8-stdlib
+        - libtinfo5
+        - python
+        - python3-minimal
+        - python3.8
+        - libglvnd0
+        - libdrm-common
+        - libdrm2
+        - libegl-mesa0
+        - libegl1
+        - libgbm1
+        - libglapi-mesa
+        - libwayland-server0
+        - libx11-xcb1
+        - libxcb-dri3-0
+        - libxcb-present0
+        - libxcb-sync1
+        - libxcb-xfixes0
+        - libxshmfence1
+        - libgstreamer1.0-0
+        - libgstreamer-plugins-bad1.0-0
+        - libpangocairo-1.0-0
 
-- name: Install core packages
-  apt:
-    name: "{{ item }}"
-    state: present
-  loop:
-    - bash-completion
-    - build-essential
-    - btrfs-progs
-    - cmake
-    - curl
-    - dnsutils
-    - htop
-    - iotop
-    - isc-dhcp-client
-    - iputils-ping
-    - kmod
-    - linux-firmware
-    - locales
-    - net-tools
-    - netplan.io
-    - pciutils
-    - python3-dev
-    - ssh
-    - sudo
-    - udev
-    - unzip
-    - usbutils
-    - neovim
-    - wpasupplicant
+    - name: Install core packages
+      apt:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - bash-completion
+        - build-essential
+        - btrfs-tools
+        - cmake
+        - curl
+        - dnsutils
+        - htop
+        - iotop
+        - isc-dhcp-client
+        - iputils-ping
+        - kmod
+        - linux-firmware
+        - locales
+        - net-tools
+        - netplan.io
+        - pciutils
+        - python3-dev
+        - ssh
+        - sudo
+        - systemd
+        - udev
+        - unzip
+        - usbutils
+        - vim
+        - wpasupplicant
 
-- name: Generate locales
-  locale_gen:
-    name: en_US.UTF-8
-    state: present
+    - name: Generate locales
+      locale_gen:
+        name: en_US.UTF-8
+        state: present
 
-- name: Enable services
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-  loop:
-    - ssh
-    - systemd-networkd
+    - name: Enable services
+      systemd:
+        name: "{{ item }}"
+        enabled: yes
+      loop:
+        - ssh
+        - systemd-networkd
 
-- name: Update network conf
-  template:
-    src: etc/netplan/netcfg.yaml
-    dest: /etc/netplan/netcfg.yaml
-    owner: root
-    group: root
-    mode: 0644
+    - name: Update network conf
+      template:
+        src: etc/netplan/netcfg.yaml
+        dest: /etc/netplan/netcfg.yaml
+        owner: root
+        group: root
+        mode: 0644
 
-- name: Create new user
-  user:
-    name: "{{ new_user.name }}"
-    shell: "{{ new_user.shell }}"
-    password: "{{ new_user.password | password_hash('sha512') }}"
-    create_home: yes
-    groups: sudo
-    state: present
+    - name: Create new user
+      user:
+        name: "{{ new_user.name }}"
+        shell: "{{ new_user.shell }}"
+        password: "{{ new_user.password | password_hash('sha512') }}"
+        create_home: yes
+        groups: sudo
+        state: present
 
-- name: Download pip
-  get_url:
-    url: https://bootstrap.pypa.io/get-pip.py
-    dest: /tmp/get-pip.py
+    - name: Download pip
+      get_url:
+        url: https://bootstrap.pypa.io/get-pip.py
+        dest: /tmp/get-pip.py
 
-- name: Install pip
-  shell: python3 /tmp/get-pip.py --user
-  become: yes
-  become_user: "{{ new_user.name }}"
+    - name: Install pip
+      shell: python3.8 /tmp/get-pip.py --user
+      become: yes
+      become_user: "{{ new_user.name }}"
+    # to avoid everything stops if one package name is wrong hence is not found for example
+    ignore_errors: yes 

--- a/ansible/roles/jetson/templates/etc/apt/sources.list
+++ b/ansible/roles/jetson/templates/etc/apt/sources.list
@@ -1,13 +1,10 @@
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }} main restricted
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }}-updates main restricted
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }} universe
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }}-updates universe
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }} multiverse
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }}-updates multiverse
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }}-backports main restricted universe multiverse
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }}-security main restricted
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }}-security universe
-deb http://ports.ubuntu.com/ubuntu-ports/ {{ ubuntu_release }}-security multiverse
-
-# Needed for libffi6
-deb http://ports.ubuntu.com/ubuntu-ports/ bionic main
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic main restricted
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main restricted
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic universe
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic-updates universe
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic-updates multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic-backports main restricted universe multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic-security main restricted
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic-security universe
+deb http://ports.ubuntu.com/ubuntu-ports/ bionic-security multiverse

--- a/create-rootfs.sh
+++ b/create-rootfs.sh
@@ -7,7 +7,7 @@
 set -e
 
 ARCH=arm64
-RELEASE=focal
+RELEASE=bionic
 
 # Check if the user is not root
 if [ "x$(whoami)" != "xroot" ]; then


### PR DESCRIPTION
Master @pythops refering to [Bionic support](https://github.com/pythops/jetson-nano-image/issues/44).

I  confirm that once this adds support for Bionic. Didn't struggle to make it minimal in the number of packages though.  

- I had to tweak the packages and used  Ansible `ignore_errors: yes` to do it faster. 
- Also made a `verbose` option to `create_rootfs.sh` and [`create_image.sh` ](https://github.com/eusoubrasileiro/jetson-nano-image/blob/69a2d9dc40b2512a202d6c4f5544ede89d1384fb/create-image.sh) to help in the task. But did not add it here. 
- I used a Focal Ubuntu and built everything native without Vagrant, Docker or any VM. That was much faster. Also did some other little customizations that can be seen on the other repo already linked. 

This adds supports to Jetpack 4.6.1 and Deepstream. Now they can install flawlessly with apt. That's important because they are huge packages and needed for many AI stuff. Nvidia stated that they are only supported by Bionic. I don't know if any hackery can install them on Focal but I am in favor to follow Nvidia instructions. 

Finally IMHO I suggest that Bionic support is more than advisable. And this PR is only a draft. Also useful for future users facing same problems. 

Anyway thanks a lot @pythops nothing of this would be possible without your work. 