### PR TITLE
Missing i2c-tools

### DIFF
--- a/ansible/roles/jetson/tasks/main.yaml
+++ b/ansible/roles/jetson/tasks/main.yaml
@@ -42,6 +42,7 @@
     - python-is-python2
     - libgstreamer1.0-0
     - libgstreamer-plugins-bad1.0-0
+    - i2c-tools
 
 - name: Install core packages
   apt:


### PR DESCRIPTION
It's needed for ota installer nvidia-l4t-bootloader package .