### PR TITLE
Fix variable names for start and end sectors

### DIFF
--- a/flash-image.sh
+++ b/flash-image.sh
@@ -57,7 +57,7 @@ start_sector=$(sgdisk -i 1 $2 | grep "First sector" | awk '{print $3}')
 # Recrate the partition
 sgdisk -d 1 $2 > /dev/null
 
-sgdisk -n 1:$start:$end $2 > /dev/null
+sgdisk -n 1:$start_sector:$end_sector $2 > /dev/null
 
 sgdisk -c 1:APP $2 > /dev/null
 


### PR DESCRIPTION
There is no $start or $end variable in this script, therefore the script will fail to resize the partition.